### PR TITLE
ww/microusb poweroff

### DIFF
--- a/board/sunxi/board.c
+++ b/board/sunxi/board.c
@@ -446,31 +446,30 @@ void sunxi_board_init(void)
 #ifdef CONFIG_AXP209_POWER
   // power down immediately if powered on by pluging in to micro usb
   unsigned int *sram_ver_reg = (unsigned int*)0x01c00024;
-  printf("0x%08x\n", *sram_ver_reg);
 
-  if( (*sram_ver_reg) & 0x0100) {
+  if( ( (*sram_ver_reg) & 0x0100 ) != 0 ) { // fel jumper set
     rc = pmic_bus_read(AXP209_POWER_STATUS, &val);
     if (rc) {
        printf("ERROR cannot read from AXP209!\n");
     } else {
-      if(val&0x1) {
-         rc=pmic_bus_read(AXP209_POWER_MODE, &val);
-         if ( val & 0x20 ) {
-           /* if there is a battery connected, shutdown */
-           printf("started by pluging in while battery connected"
-                  " -> powering down again\n");
-           rc=pmic_bus_read(AXP209_SHUTDOWN, &val);
+      if( ! (val & 0x1) ) { // Cable not connected
+        rc=pmic_bus_read(AXP209_POWER_MODE, &val);
+        if ( val & 0x20 ) {
+          /* if there is a battery connected, shutdown */
+          printf("started by pluging in while battery connected"
+                 " -> powering down again\n");
+          rc=pmic_bus_read(AXP209_SHUTDOWN, &val);
       
-           if(rc) {
-             printf("ERROR cannot read from AXP209!\n");
-           }
+          if(rc) {
+            printf("ERROR cannot read from AXP209!\n");
+          }
       
-           val |= 128;
-           rc = pmic_bus_write(AXP209_SHUTDOWN, val);
-           if(rc) {
-             printf("ERROR cannot write to AXP209!\n");
-           }
-         }
+          val |= 128;
+          rc = pmic_bus_write(AXP209_SHUTDOWN, val);
+          if(rc) {
+            printf("ERROR cannot write to AXP209!\n");
+          }
+        }
       }
     }
   } else {

--- a/board/sunxi/board.c
+++ b/board/sunxi/board.c
@@ -447,7 +447,7 @@ void sunxi_board_init(void)
   // power down immediately if powered on by pluging in to micro usb
   unsigned int *sram_ver_reg = (unsigned int*)0x01c00024;
 
-  if( ( (*sram_ver_reg) & 0x0100 ) != 0 ) { // fel jumper set
+  if( ( (*sram_ver_reg) & 0x0100 ) != 0 ) { // fel jumper not set
     rc = pmic_bus_read(AXP209_POWER_STATUS, &val);
     if (rc) {
        printf("ERROR cannot read from AXP209!\n");


### PR DESCRIPTION
Fixes functionality that allows the chip to power off when a microusb is plugged in when not in fel mode and a battery is connected.