### PR TITLE
Find autoconf.h in $(objdir) rather than $(srcdir)

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -206,7 +206,7 @@ endif # !LOGO_BMP
 # Define _GNU_SOURCE to obtain the getline prototype from stdio.h
 #
 HOST_EXTRACFLAGS += -include $(srctree)/include/libfdt_env.h \
-		-include $(srctree)/include/generated/autoconf.h \
+		-include $(objtree)/include/generated/autoconf.h \
 		$(patsubst -I%,-idirafter%, $(filter -I%, $(UBOOTINCLUDE))) \
 		-I$(srctree)/lib/libfdt \
 		-I$(srctree)/tools \


### PR DESCRIPTION
When using a build directory that is different than the source directory
the include of "generated/autoconf.h" will fail since it is not in the source tree.